### PR TITLE
Fix for Folder syncing does not delete extraneous files bug.

### DIFF
--- a/lib/vagrant-openstack/action/sync_folders.rb
+++ b/lib/vagrant-openstack/action/sync_folders.rb
@@ -38,7 +38,7 @@ module VagrantPlugins
 
             # Rsync over to the guest path using the SSH info
             command = [
-              "rsync", "--verbose", "--archive", "-z",
+              "rsync", "--verbose", "--archive", "--compress", "--delete",
               "-e", "ssh -p #{ssh_info[:port]} -i '#{ssh_info[:private_key_path]}' -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
               hostpath,
               "#{ssh_info[:username]}@#{ssh_info[:host]}:#{guestpath}"]


### PR DESCRIPTION
Rsync now uses --delete flag to make sure source and destination are the same.
