### PR TITLE
Fix HandleBoxUrl middleware deprecation warning

### DIFF
--- a/lib/vagrant-openstack/action.rb
+++ b/lib/vagrant-openstack/action.rb
@@ -58,7 +58,7 @@ module VagrantPlugins
 
       def self.action_up
         Vagrant::Action::Builder.new.tap do |b|
-          b.use HandleBoxUrl
+          b.use defined?(HandleBox) ? HandleBox : HandleBoxUrl
           b.use ConfigValidate
           b.use Call, Created do |env, b2|
             unless env[:result]


### PR DESCRIPTION
Vagrant 1.5 deprecated HandleBoxUrl in favor of HandleBox.

Use HandleBox if defined and HandleBoxUrl otherwise
to preserve backward compatibility for Vagrant <1.5.
