### PR TITLE
Add configurable build timeout and progress display

### DIFF
--- a/lib/vagrant-openstack-cloud-provider/config.rb
+++ b/lib/vagrant-openstack-cloud-provider/config.rb
@@ -70,6 +70,14 @@ module VagrantPlugins
       # @return [Hash]
       attr_accessor :scheduler_hints
 
+      # @return [String]
+      attr_accessor :instance_build_timeout
+
+      # @return [Bool]
+      attr_accessor :report_progress
+      # alias_method :report_progress?, :report_progress
+
+
       def initialize
         @api_key  = UNSET_VALUE
         @endpoint = UNSET_VALUE
@@ -86,6 +94,8 @@ module VagrantPlugins
         @networks = UNSET_VALUE
         @tenant = UNSET_VALUE
         @scheduler_hints = UNSET_VALUE
+        @instance_build_timeout = UNSET_VALUE
+        @report_progress = UNSET_VALUE
       end
 
       def finalize!
@@ -111,6 +121,8 @@ module VagrantPlugins
         @networks = [@public_network_name] if @networks == UNSET_VALUE
         @tenant = nil if @tenant == UNSET_VALUE
         @scheduler_hints = {} if @scheduler_hints == UNSET_VALUE
+        @instance_build_timeout = 120 if @instance_build_timeout == UNSET_VALUE
+        @report_progress = true if @report_progress == UNSET_VALUE
       end
 
       def validate(machine)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -14,8 +14,10 @@ en:
       Launching a server with the following settings...
     not_created: |-
       The server hasn't been created yet. Run `vagrant up` first.
+    active: |-
+      The server was built in %{elapsed} seconds!
     ready: |-
-      The server is ready!
+      The server is ready after %{elapsed} seconds!
     rsync_folder: |-
       Rsyncing folder: %{hostpath} => %{guestpath}
     waiting_for_build: |-

--- a/spec/vagrant-openstack-cloud-provider/config_spec.rb
+++ b/spec/vagrant-openstack-cloud-provider/config_spec.rb
@@ -26,6 +26,8 @@ describe VagrantPlugins::OpenStack::Config do
     its(:networks) { should eq(["public"]) }
     its(:tenant) { should be_nil }
     its(:scheduler_hints) { should eq({}) }
+    its(:instance_build_timeout) { should eq(120) }
+    its(:report_progress) { should be_true }
   end
 
   describe "overriding defaults" do
@@ -42,7 +44,9 @@ describe VagrantPlugins::OpenStack::Config do
       :public_network_name,
       :networks,
       :tenant,
-      :scheduler_hints].each do |attribute|
+      :scheduler_hints,
+      :instance_build_timeout,
+      :report_progress].each do |attribute|
       it "should not default #{attribute} if overridden" do
         subject.send("#{attribute}=", "foo")
         subject.finalize!

--- a/vagrant-openstack-cloud-provider.gemspec
+++ b/vagrant-openstack-cloud-provider.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "fog", "~> 1.22"
 
-  gem.add_development_dependency "rake"
+  gem.add_development_dependency "rake", '< 11.0'
   gem.add_development_dependency "rspec", "~> 2.13.0"
 
   gem.files         = `git ls-files`.split($/)


### PR DESCRIPTION
To support slower or faster builds, the instance_build_timeout config
allows to control how long we wait for the instance to finish building
(get to ACTIVE state)

To support easier parallelism in console display, the progress can
be hidden