### PR TITLE
Make SSH timeout values configurable

### DIFF
--- a/lib/vagrant-openstack-cloud-provider/config.rb
+++ b/lib/vagrant-openstack-cloud-provider/config.rb
@@ -72,10 +72,16 @@ module VagrantPlugins
       attr_accessor :scheduler_hints
 
       # @return [Integer]
-      casting_attr_accessor :instance_build_timeout, Integer
+      casting_attr_accessor :instance_build_timeout, Integer, greater_than(0)
 
       # @return [Integer]
       casting_attr_accessor :instance_build_status_check_interval, Integer, greater_than(0)
+
+      # @return [Integer]
+      casting_attr_accessor :instance_ssh_timeout, Integer, greater_than(0)
+
+      # @return [Integer]
+      casting_attr_accessor :instance_ssh_check_interval, Integer, greater_than(0)
 
       # @return [Bool]
       attr_accessor :report_progress
@@ -99,6 +105,8 @@ module VagrantPlugins
         @scheduler_hints = UNSET_VALUE
         @instance_build_timeout = UNSET_VALUE
         @instance_build_status_check_interval = UNSET_VALUE
+        @instance_ssh_timeout = UNSET_VALUE
+        @instance_ssh_check_interval = UNSET_VALUE
         @report_progress = UNSET_VALUE
       end
 
@@ -127,6 +135,9 @@ module VagrantPlugins
         @scheduler_hints = {} if @scheduler_hints == UNSET_VALUE
         @instance_build_timeout = 120 if @instance_build_timeout == UNSET_VALUE
         @instance_build_status_check_interval = 1 if @instance_build_status_check_interval == UNSET_VALUE
+        @instance_ssh_timeout = 60 if @instance_ssh_timeout == UNSET_VALUE
+        @instance_ssh_check_interval = 2 if @instance_ssh_check_interval == UNSET_VALUE
+
         @report_progress = true if @report_progress == UNSET_VALUE
       end
 

--- a/spec/vagrant-openstack-cloud-provider/action/create_server_spec.rb
+++ b/spec/vagrant-openstack-cloud-provider/action/create_server_spec.rb
@@ -35,7 +35,7 @@ describe VagrantPlugins::OpenStack::Action::CreateServer do
       communicate.stub(:ready?).and_return(true)
       machine.stub(:communicate).and_return(communicate)
       env = { :ui => ui, :interrupted => false, :machine => machine }
-      subject.send('ssh_is_responding?', env)
+      subject.send('ssh_is_responding?', env, timeout=1, sleep_interval=0.001)
     end
 
     it "should raise if ssh isn't available" do
@@ -43,7 +43,7 @@ describe VagrantPlugins::OpenStack::Action::CreateServer do
       communicate.stub(:ready?).and_return(false)
       machine.stub(:communicate).and_return(communicate)
       env = { :ui => ui, :interrupted => false, :machine => machine }
-      expect { subject.send('ssh_is_responding?', env) }.to raise_error(VagrantPlugins::OpenStack::Errors::SshUnavailable)
+      expect { subject.send('ssh_is_responding?', env, timeout=1, sleep_interval=0.001) }.to raise_error(VagrantPlugins::OpenStack::Errors::SshUnavailable)
     end
   end
 

--- a/spec/vagrant-openstack-cloud-provider/config_spec.rb
+++ b/spec/vagrant-openstack-cloud-provider/config_spec.rb
@@ -28,6 +28,8 @@ describe VagrantPlugins::OpenStack::Config do
     its(:scheduler_hints) { should eq({}) }
     its(:instance_build_timeout) { should eq(120) }
     its(:instance_build_status_check_interval) { should eq(1) }
+    its(:instance_ssh_timeout) { should eq(60) }
+    its(:instance_ssh_check_interval) { should eq(2) }
     its(:report_progress) { should be_true }
   end
 
@@ -57,7 +59,9 @@ describe VagrantPlugins::OpenStack::Config do
 
   describe "overriding defaults - integers" do
     [:instance_build_timeout,
-     :instance_build_status_check_interval].each do |attribute|
+     :instance_build_status_check_interval,
+     :instance_ssh_timeout,
+     :instance_ssh_check_interval].each do |attribute|
       it "should not default #{attribute} if overridden" do
         subject.send("#{attribute}=", 12345)
         subject.finalize!
@@ -95,8 +99,10 @@ describe VagrantPlugins::OpenStack::Config do
 
     context "the numeric values" do
       [:instance_build_timeout,
-       :instance_build_status_check_interval].each do |attribute|
-        it "should cast receiving value to an int" do
+       :instance_build_status_check_interval,
+       :instance_ssh_timeout,
+       :instance_ssh_check_interval].each do |attribute|
+        it "should cast #{attribute} to an int" do
           subject.send("#{attribute}=", "100")
           subject.finalize!
           subject.send(attribute).should == 100
@@ -107,12 +113,16 @@ describe VagrantPlugins::OpenStack::Config do
       end
     end
 
-    context "the instance build status check interval should be a non-null positive integer" do
-      it "should cast receiving value to an int" do
-        expect { subject.send("#{:instance_build_status_check_interval}=", "0") }.to raise_error
-        expect { subject.send("#{:instance_build_status_check_interval}=", -1) }.to raise_error
+    context "non-null positive integers" do
+      [:instance_build_timeout,
+       :instance_build_status_check_interval,
+       :instance_ssh_timeout,
+       :instance_ssh_check_interval].each do |attribute|
+        it "should cast #{attribute} to an int" do
+          expect { subject.send("#{attribute}=", "0") }.to raise_error
+          expect { subject.send("#{attribute}=", -1) }.to raise_error
+        end
       end
     end
-
   end
 end


### PR DESCRIPTION
Currently, SSH timeout was fixed at 120 seconds (60 tries x 2 seconds
sleep interval). This slowed down tests and did not allow users to
configure their own timeout values.

This commit addresses the problem by making timeouts configurable.
Finally, the unit tests use smaller values for testing ssh timeout.