### PR TITLE
Add the error's reason to the SSH unavailable exception

### DIFF
--- a/lib/vagrant-openstack-cloud-provider/action/create_server.rb
+++ b/lib/vagrant-openstack-cloud-provider/action/create_server.rb
@@ -156,9 +156,12 @@ module VagrantPlugins
                end
                sleep sleep_interval
              end
-             raise unless env[:machine].communicate.ready?
-           rescue
-             raise Errors::SshUnavailable
+             unless env[:machine].communicate.ready?
+                raise Errors::SshWaitTimeout.new(
+                    :seconds => sleep_interval * (timeout / sleep_interval))
+             end
+           rescue Exception => msg
+             raise Errors::SshUnavailable.new(:error => msg)
            end
         end
 

--- a/lib/vagrant-openstack-cloud-provider/errors.rb
+++ b/lib/vagrant-openstack-cloud-provider/errors.rb
@@ -11,6 +11,10 @@ module VagrantPlugins
         error_key(:create_bad_state)
       end
 
+      class SshWaitTimeout < VagrantOpenStackError
+        error_key(:ssh_wait_timeout)
+      end
+
       class SshUnavailable < VagrantOpenStackError
         error_key(:ssh_unavailable)
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -37,9 +37,10 @@ en:
         state: '%{state}', instead of properly booting. Run `vagrant status`
         to find out what can be done about this state, or `vagrant destroy`
         if you want to start over.
+      ssh_wait_timeout: |-
+        The server is not ready for SSH communication after %{seconds} seconds.
       ssh_unavailable: |-
-        The server has been created successfully but it refuses incoming
-        ssh connections.
+        The server's SSH failed to become available because: %{error}.
       no_matching_flavor: |-
         No matching flavor was found! Please check your flavor setting
         to make sure you have a valid flavor chosen.


### PR DESCRIPTION
When it was failing there were no way to determining whether it was
the timeout or an alternative reason, and when it was an alternative
reason we couldn't know what it is.

To assert error messages correctly, i18n had to be activated in the
tests