### PR TITLE
Fix the ssh default timeout

### DIFF
--- a/lib/vagrant-openstack-cloud-provider/config.rb
+++ b/lib/vagrant-openstack-cloud-provider/config.rb
@@ -135,7 +135,7 @@ module VagrantPlugins
         @scheduler_hints = {} if @scheduler_hints == UNSET_VALUE
         @instance_build_timeout = 120 if @instance_build_timeout == UNSET_VALUE
         @instance_build_status_check_interval = 1 if @instance_build_status_check_interval == UNSET_VALUE
-        @instance_ssh_timeout = 60 if @instance_ssh_timeout == UNSET_VALUE
+        @instance_ssh_timeout = 120 if @instance_ssh_timeout == UNSET_VALUE
         @instance_ssh_check_interval = 2 if @instance_ssh_check_interval == UNSET_VALUE
 
         @report_progress = true if @report_progress == UNSET_VALUE

--- a/spec/vagrant-openstack-cloud-provider/config_spec.rb
+++ b/spec/vagrant-openstack-cloud-provider/config_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe VagrantPlugins::OpenStack::Config do
     it { is_expected.to have_attributes(scheduler_hints: {}) }
     it { is_expected.to have_attributes(instance_build_timeout: 120) }
     it { is_expected.to have_attributes(instance_build_status_check_interval: 1) }
-    it { is_expected.to have_attributes(instance_ssh_timeout: 60) }
+    it { is_expected.to have_attributes(instance_ssh_timeout: 120) }
     it { is_expected.to have_attributes(instance_ssh_check_interval: 2) }
     it { is_expected.to have_attributes(report_progress: true) }
   end


### PR DESCRIPTION
The previous timeout was 120 seconds (60 times 2 seconds)
The new default is 60 seconds (30 times 2 seconds)
It was most probably an error to change it when making
the fields configurable