### PR TITLE
Pin fog-core to 1.43

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 rvm:
-- 2.0.0
+- 2.2.5
 deploy:
   provider: rubygems
   api_key:

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git", :tag => 'v1.8.1'
+  gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git", :tag => 'v1.9.4'
   gem 'simplecov', :require => false
 end

--- a/lib/vagrant-openstack-cloud-provider/version.rb
+++ b/lib/vagrant-openstack-cloud-provider/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module OpenStack
-    VERSION = "1.1.12"
+    VERSION = "1.1.13"
   end
 end

--- a/vagrant-openstack-cloud-provider.gemspec
+++ b/vagrant-openstack-cloud-provider.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "http://www.vagrantup.com"
 
   gem.add_runtime_dependency "fog", "~> 1.22"
+  gem.add_runtime_dependency "fog-core", "~> 1.43.0"
   gem.add_runtime_dependency "promise", "~> 0.3.1"
 
   gem.add_development_dependency "rake", '< 11.0'


### PR DESCRIPTION
Because vagrant bundles only ruby 2.2.x and fog is dependent
on fog-core 1.44.0 that is dependent of xmlrpc 0.3.0 and only
working with ruby 2.3 and up.

Bumped to latest version of vagrant (1.9.4) ruby 2.2.5 to
make sure the it works with those