### PR TITLE
Depend on fog-openstack rather than fog

### DIFF
--- a/lib/vagrant-openstack-cloud-provider/action/connect_openstack.rb
+++ b/lib/vagrant-openstack-cloud-provider/action/connect_openstack.rb
@@ -1,4 +1,4 @@
-require "fog"
+require "fog/openstack"
 require "log4r"
 require 'promise'
 

--- a/lib/vagrant-openstack-cloud-provider/action/create_server.rb
+++ b/lib/vagrant-openstack-cloud-provider/action/create_server.rb
@@ -1,4 +1,4 @@
-require "fog"
+require "fog/openstack"
 require "log4r"
 require "json"
 

--- a/spec/vagrant-openstack-cloud-provider/action/connect_openstack_spec.rb
+++ b/spec/vagrant-openstack-cloud-provider/action/connect_openstack_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'vagrant-openstack-cloud-provider/errors'
 require 'vagrant-openstack-cloud-provider/action/connect_openstack'
-require "fog"
+require "fog/openstack"
 
 RSpec.describe VagrantPlugins::OpenStack::Action::ConnectOpenStack do
   describe '#call?' do

--- a/vagrant-openstack-cloud-provider.gemspec
+++ b/vagrant-openstack-cloud-provider.gemspec
@@ -13,8 +13,7 @@ Gem::Specification.new do |gem|
   gem.summary       = "Enables Vagrant to manage machines in OpenStack Cloud."
   gem.homepage      = "http://www.vagrantup.com"
 
-  gem.add_runtime_dependency "fog", "~> 1.22"
-  gem.add_runtime_dependency "fog-core", "~> 1.43.0"
+  gem.add_runtime_dependency "fog-openstack", "~> 0.1.26"
   gem.add_runtime_dependency "promise", "~> 0.3.1"
 
   gem.add_development_dependency "rake", '< 11.0'


### PR DESCRIPTION
The latest version of fog-xenserver requires xmlrpc that is
incompatible with ruby 2.2.x.
By using fog-openstack we don't need to get xmlrpc,
it's the suggested way to depend on fog.